### PR TITLE
Add option to change eSCO Transport Unit Size to 16

### DIFF
--- a/device/src/esco_parameters.cc
+++ b/device/src/esco_parameters.cc
@@ -18,6 +18,7 @@
 
 #include "base/logging.h"
 
+#include "bt_target.h"
 #include "device/include/esco_parameters.h"
 
 static const enh_esco_params_t default_esco_parameters[ESCO_NUM_CODECS] = {
@@ -48,8 +49,8 @@ static const enh_esco_params_t default_esco_parameters[ESCO_NUM_CODECS] = {
      .output_pcm_payload_msb_position = 0,
      .input_data_path = ESCO_DATA_PATH_PCM,
      .output_data_path = ESCO_DATA_PATH_PCM,
-     .input_transport_unit_size = 0x00,
-     .output_transport_unit_size = 0x00,
+     .input_transport_unit_size = ESCO_TRANSPORT_UNIT_SIZE,
+     .output_transport_unit_size = ESCO_TRANSPORT_UNIT_SIZE,
 #if (BTA_HFP_VERSION >= HFP_VERSION_1_7)
      .max_latency_ms = 12,
 #else
@@ -96,8 +97,8 @@ static const enh_esco_params_t default_esco_parameters[ESCO_NUM_CODECS] = {
      .output_pcm_payload_msb_position = 0,
      .input_data_path = ESCO_DATA_PATH_PCM,
      .output_data_path = ESCO_DATA_PATH_PCM,
-     .input_transport_unit_size = 0x00,
-     .output_transport_unit_size = 0x00,
+     .input_transport_unit_size = ESCO_TRANSPORT_UNIT_SIZE,
+     .output_transport_unit_size = ESCO_TRANSPORT_UNIT_SIZE,
      .max_latency_ms = 8,
      .packet_types =
          (ESCO_PKT_TYPES_MASK_EV3 | ESCO_PKT_TYPES_MASK_NO_3_EV3 |
@@ -131,8 +132,8 @@ static const enh_esco_params_t default_esco_parameters[ESCO_NUM_CODECS] = {
      .output_pcm_payload_msb_position = 0,
      .input_data_path = ESCO_DATA_PATH_PCM,
      .output_data_path = ESCO_DATA_PATH_PCM,
-     .input_transport_unit_size = 0x00,
-     .output_transport_unit_size = 0x00,
+     .input_transport_unit_size = ESCO_TRANSPORT_UNIT_SIZE,
+     .output_transport_unit_size = ESCO_TRANSPORT_UNIT_SIZE,
      .max_latency_ms = 13,
      .packet_types =
          (ESCO_PKT_TYPES_MASK_EV3 | ESCO_PKT_TYPES_MASK_NO_3_EV3 |

--- a/internal_include/bt_target.h
+++ b/internal_include/bt_target.h
@@ -292,6 +292,16 @@
 #define BTM_SCO_ENHANCED_SYNC_ENABLED TRUE
 #endif
 
+/*  This is used to work around an uncompliant AOSP implementation regarding
+ *  eSCO Transport Unit Size parameter defined as 0x00 (HCI) which is not
+ *  suitable for all devices. This sets this parameter to 16 bits (PCM)
+ */
+#ifdef BTM_ESCO_TRANSPORT_UNIT_SIZE_PCM16
+#define ESCO_TRANSPORT_UNIT_SIZE 16
+#else
+#define ESCO_TRANSPORT_UNIT_SIZE 0x00
+#endif
+
 /**************************
  * Initial SCO TX credit
  ************************/


### PR DESCRIPTION
 * Fixes bluetooth calls in many samsung devices

[SamarV-121: Make it conditional and apply it for mSBC T1, CVSD codec as well]